### PR TITLE
Return null on unsupported history and data download requests

### DIFF
--- a/QuantConnect.ZerodhaBrokerage.Tests/ZerodhaBrokerageHistoryProviderTests.cs
+++ b/QuantConnect.ZerodhaBrokerage.Tests/ZerodhaBrokerageHistoryProviderTests.cs
@@ -31,6 +31,8 @@ namespace QuantConnect.Tests.Brokerages.Zerodha
         {
             get
             {
+                TestGlobals.Initialize();
+
                 return new[]
                 {
                     // valid parameters
@@ -50,6 +52,9 @@ namespace QuantConnect.Tests.Brokerages.Zerodha
 
                     // invalid data type
                     new TestCaseData(Symbols.SBIN, Resolution.Minute, Time.OneHour, typeof(QuoteBar), true),
+
+                    // invalid market
+                    new TestCaseData(Symbol.Create("SBIN", SecurityType.Equity, Market.USA), Resolution.Minute, Time.OneHour, typeof(TradeBar), true),
                 };
             }
         }

--- a/QuantConnect.ZerodhaBrokerage/ZerodhaBrokerage.cs
+++ b/QuantConnect.ZerodhaBrokerage/ZerodhaBrokerage.cs
@@ -112,6 +112,7 @@ namespace QuantConnect.Brokerages.Zerodha
         private bool _historySecurityTypeErrorFlag;
         private bool _historyResolutionErrorFlag;
         private bool _historyDateRangeErrorFlag;
+        private bool _historyMarketErrorFlag;
 
         #endregion Declarations
 
@@ -882,6 +883,17 @@ namespace QuantConnect.Brokerages.Zerodha
                     OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidSecurityType",
                         $"{request.Symbol.SecurityType} security type not supported, no history returned"));
                     _historySecurityTypeErrorFlag = true;
+                }
+                return null;
+            }
+
+            if (request.Symbol.ID.Market != Market.India)
+            {
+                if (!_historyMarketErrorFlag)
+                {
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidMarket",
+                        $"{request.Symbol.ID.Market} market not supported, no history returned"));
+                    _historyMarketErrorFlag = true;
                 }
                 return null;
             }

--- a/QuantConnect.ZerodhaBrokerage/ZerodhaBrokerage.cs
+++ b/QuantConnect.ZerodhaBrokerage/ZerodhaBrokerage.cs
@@ -109,6 +109,9 @@ namespace QuantConnect.Brokerages.Zerodha
         private DateTime _lastTradeTickTime;
         private bool _historyDataTypeErrorFlag;
         private bool _isInitialized;
+        private bool _historySecurityTypeErrorFlag;
+        private bool _historyResolutionErrorFlag;
+        private bool _historyDateRangeErrorFlag;
 
         #endregion Declarations
 
@@ -859,43 +862,50 @@ namespace QuantConnect.Brokerages.Zerodha
         /// <returns>An enumerable of bars covering the span specified in the request</returns>
         public override IEnumerable<BaseData> GetHistory(HistoryRequest request)
         {
-            if (request.DataType != typeof(TradeBar) && !_historyDataTypeErrorFlag)
+            if (request.DataType != typeof(TradeBar))
             {
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidBarType",
-                    $"{request.DataType} type not supported, no history returned"));
-                _historyDataTypeErrorFlag = true;
-                yield break;
+                if (!_historyDataTypeErrorFlag)
+                {
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidBarType",
+                        $"{request.DataType} type not supported, no history returned"));
+                    _historyDataTypeErrorFlag = true;
+                }
+                return null;
             }
 
-            if (request.Symbol.SecurityType != SecurityType.Equity && request.Symbol.SecurityType != SecurityType.Future && request.Symbol.SecurityType != SecurityType.Option)
+            if (request.Symbol.SecurityType != SecurityType.Equity &&
+                request.Symbol.SecurityType != SecurityType.Future &&
+                request.Symbol.SecurityType != SecurityType.Option)
             {
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidSecurityType",
-                    $"{request.Symbol.SecurityType} security type not supported, no history returned"));
-                yield break;
+                if (!_historySecurityTypeErrorFlag)
+                {
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidSecurityType",
+                        $"{request.Symbol.SecurityType} security type not supported, no history returned"));
+                    _historySecurityTypeErrorFlag = true;
+                }
+                return null;
             }
 
             if (request.Resolution == Resolution.Tick || request.Resolution == Resolution.Second)
             {
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidResolution",
-                    $"{request.Resolution} resolution not supported, no history returned"));
-                yield break;
+                if (!_historyResolutionErrorFlag)
+                {
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidResolution",
+                        $"{request.Resolution} resolution not supported, no history returned"));
+                    _historyResolutionErrorFlag = true;
+                }
+                return null;
             }
 
             if (request.StartTimeUtc >= request.EndTimeUtc)
             {
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidDateRange",
-                    "The history request start date must precede the end date, no history returned"));
-                yield break;
-            }
-
-            if (request.Symbol.ID.SecurityType != SecurityType.Equity && request.Symbol.ID.SecurityType != SecurityType.Future && request.Symbol.ID.SecurityType != SecurityType.Option)
-            {
-                throw new ArgumentException("Zerodha does not support this security type: " + request.Symbol.ID.SecurityType);
-            }
-
-            if (request.StartTimeUtc >= request.EndTimeUtc)
-            {
-                throw new ArgumentException("Invalid date range specified");
+                if (!_historyDateRangeErrorFlag)
+                {
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "InvalidDateRange",
+                        "The history request start date must precede the end date, no history returned"));
+                    _historyDateRangeErrorFlag = true;
+                }
+                return null;
             }
 
             var history = Enumerable.Empty<BaseData>();
@@ -924,10 +934,7 @@ namespace QuantConnect.Brokerages.Zerodha
                 }
             }
 
-            foreach (var baseData in history)
-            {
-                yield return baseData;
-            }
+            return history;
         }
 
         private void Initialize(string tradingSegment, string zerodhaProductType, string apiKey, string apiSecret,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Returning null on unsupported history requests instead of returning an empty enumerable. This allows to differentiate empty results from unsupported cases.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
